### PR TITLE
Implement organisation-wide pull request template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # .github
-Organisational defaults
+
+This is a meta-repo where GitHub 'health' files can be specified that will apply to all repositories inside this GitHub account.
+If you would like to override a default set from this repo, just create the same file in the base directory of your respository and it will use that version instead of this default.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -8,18 +8,8 @@ Relevant JIRA ticket: [KZN-XXX](https://kzngroup.atlassian.net/browse/KZN-XXX)
 
 <!--- Provide a link to the newly created or updated documentation relevant to this PR -->
 
-## Change type
-
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-
 ## Checklist
 
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If one of the below isn't complete (and should be), please go and polish that off before creating a PR. -->
-- [ ] Linting has been applied to my code.
-- [ ] Relevant documentation has been updated.
-- [ ] Tests have been written where possible.
 - [ ] I have satisfied the [KZN Definition of Done](https://kzngroup.atlassian.net/wiki/spaces/COMMUNITY/pages/209059874/KZN+Definition+of+Done).

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,20 @@
+<!--- Please fill your JIRA ticket in below, both in the text and link. -->
+Relevant JIRA ticket: [KZN-XXX](https://kzngroup.atlassian.net/browse/KZN-XXX)
+
+## Description of Changes
+
+## Change type
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If one of the below isn't complete, please go and polish that off before creating a PR. -->
+- [ ] Linting has been applied to my code.
+- [ ] Relevant documentation has been updated.
+- [ ] Tests have been written where possible.
+- [ ] I have satisfied the [KZN Definition of Done](https://kzngroup.atlassian.net/wiki/spaces/COMMUNITY/pages/209059874/KZN+Definition+of+Done).

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -3,6 +3,11 @@ Relevant JIRA ticket: [KZN-XXX](https://kzngroup.atlassian.net/browse/KZN-XXX)
 
 ## Description of Changes
 
+
+## Documentation for Review
+
+<!--- Provide a link to the newly created or updated documentation relevant to this PR -->
+
 ## Change type
 
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
@@ -13,7 +18,7 @@ Relevant JIRA ticket: [KZN-XXX](https://kzngroup.atlassian.net/browse/KZN-XXX)
 ## Checklist
 
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If one of the below isn't complete, please go and polish that off before creating a PR. -->
+<!--- If one of the below isn't complete (and should be), please go and polish that off before creating a PR. -->
 - [ ] Linting has been applied to my code.
 - [ ] Relevant documentation has been updated.
 - [ ] Tests have been written where possible.


### PR DESCRIPTION
<!--- Please fill your JIRA ticket in below, both in the text and link. -->
Relevant JIRA ticket: [KZNSYSADM-542](https://kzngroup.atlassian.net/browse/KZNSYSADM-542)

## Description of Changes
Adding a pull request template (seen here) to all repos in our organisation.

The purpose of a pull request template like this is prompting people to acknowledge they have completed the non-code components of a change, to reduce the habit of 'ill do that later' and make us consciously acknowledge work that should be done when we open a pull request, but sometimes isn't.

Downside to a more 'cluttered' template like the one you see here is the overhead of having to fill it out on every PR, and some of the questions will be irrelevant sometimes. For example you can see below I haven't ticked that linting has been applied, as it is not relevant to this pull request. I think we (the requester and the reviewer) can apply common sense and skip over checklist items that both agree are not relevant.

I'm completely open to ideas of if this template is overkill and something simpler is more suitable, or if we want a template at all.

## Documentation for Review

https://kzngroup.atlassian.net/wiki/spaces/COMMUNITY/pages/497582094/KZN+Ops+Playbook#KZNOpsPlaybook-PullRequestTemplate

## Change type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If one of the below isn't complete, please go and polish that off before creating a PR. -->
- [ ] Linting has been applied to my code.
- [x] Relevant documentation has been updated.
- [ ] Tests have been written where possible.
- [X] I have satisfied the [KZN Definition of Done](https://kzngroup.atlassian.net/wiki/spaces/COMMUNITY/pages/209059874/KZN+Definition+of+Done).
