### PR TITLE
TruffleHog added

### DIFF
--- a/workflows/trufflehog.yml
+++ b/workflows/trufflehog.yml
@@ -1,0 +1,39 @@
+name: TruffleHog Committed Credentials
+on:
+  push:
+  pull_request:
+jobs:
+  TruffleHog:
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args:  --only-verified
+      - name: Slack send 
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: C773NFUBU
+          payload: |
+            {
+              "text": "GitHub Committing Credentials",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "******************** \n WARNING! Credentials are being committed in the following repository: \n ${{ github.event.pull_request.html_url || github.event.head_commit.url }} \n \n See the TruffleHog output at: ${{github.event.repository.url}}/actions \n ******************** \n"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.TRUFFLEHOG }}


### PR DESCRIPTION
<!--- Please fill your JIRA ticket in below, both in the text and link. -->
Relevant JIRA ticket: [KZN-571](https://kzngroup.atlassian.net/browse/KZNSYSADM-571)

## Description of Changes
Addition of TruffleHog to GitHub actions. When using this template if a credential is committed the TruffleHog will fail and send a message to slack with a link to the repo & the action log. 

## Documentation for Review



## Checklist

- [X] I have satisfied the [KZN Definition of Done](https://kzngroup.atlassian.net/wiki/spaces/COMMUNITY/pages/209059874/KZN+Definition+of+Done).
